### PR TITLE
[RFC] Signature help stoppable

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -1022,7 +1022,7 @@ function! s:ClearSignatureHelp()
 
   call timer_stop( s:pollers.signature_help.id )
   let s:signature_help = s:default_signature_help
-  call s:Pyeval( 'ycm_state.UpdateSignatureHelp( {} )' )
+  call s:Pyeval( 'ycm_state.ClearSignatureHelp()' )
 endfunction
 
 

--- a/python/ycm/client/base_request.py
+++ b/python/ycm/client/base_request.py
@@ -107,11 +107,20 @@ class BaseRequest( object ):
                           handler,
                           timeout = _READ_TIMEOUT_SEC,
                           display_message = True,
-                          truncate_message = False ):
+                          truncate_message = False,
+                          payload = None ):
     return self.HandleFuture(
-        BaseRequest._TalkToHandlerAsync( '', handler, 'GET', timeout ),
+        self.GetDataFromHandlerAsync( handler, timeout, payload ),
         display_message,
         truncate_message )
+
+
+  def GetDataFromHandlerAsync( self,
+                               handler,
+                               timeout = _READ_TIMEOUT_SEC,
+                               payload = None ):
+    return BaseRequest._TalkToHandlerAsync(
+        '', handler, 'GET', timeout, payload )
 
 
   # This is the blocking version of the method. See below for async.
@@ -147,7 +156,8 @@ class BaseRequest( object ):
   def _TalkToHandlerAsync( data,
                            handler,
                            method,
-                           timeout = _READ_TIMEOUT_SEC ):
+                           timeout = _READ_TIMEOUT_SEC,
+                           payload = None ):
     request_uri = _BuildUri( handler )
     if method == 'POST':
       sent_data = _ToUtf8Json( data )
@@ -169,7 +179,8 @@ class BaseRequest( object ):
     return BaseRequest.Session().get(
       request_uri,
       headers = headers,
-      timeout = ( _CONNECT_TIMEOUT_SEC, timeout ) )
+      timeout = ( _CONNECT_TIMEOUT_SEC, timeout ),
+      params = payload )
 
 
   @staticmethod

--- a/python/ycm/youcompleteme.py
+++ b/python/ycm/youcompleteme.py
@@ -45,6 +45,7 @@ from ycm.client.completer_available_request import SendCompleterAvailableRequest
 from ycm.client.command_request import SendCommandRequest
 from ycm.client.completion_request import CompletionRequest
 from ycm.client.signature_help_request import SignatureHelpRequest
+from ycm.client.signature_help_request import SigHelpAvailableByFileType
 from ycm.client.debug_info_request import ( SendDebugInfoRequest,
                                             FormatDebugInfoResponse )
 from ycm.client.omni_completion_request import OmniCompletionRequest
@@ -115,6 +116,7 @@ class YouCompleteMe( object ):
     self._buffers = None
     self._latest_completion_request = None
     self._latest_signature_help_request = None
+    self._signature_help_available_requests = SigHelpAvailableByFileType()
     self._signature_help_state = signature_help.SignatureHelpState()
     self._logger = logging.getLogger( 'ycm' )
     self._client_logfile = None
@@ -331,6 +333,20 @@ class YouCompleteMe( object ):
 
 
   def SendSignatureHelpRequest( self ):
+    filetype = vimsupport.CurrentFiletypes()[ 0 ]
+    if not self._signature_help_available_requests[ filetype ].Done():
+      return
+
+    sig_help_available = self._signature_help_available_requests[
+        filetype ].Response()
+    if sig_help_available == 'NO':
+      return
+
+    if sig_help_available == 'PENDING':
+      # Send another /signature_help_available request
+      self._signature_help_available_requests[ filetype ].Start( filetype )
+      return
+
     if not self.NativeFiletypeCompletionUsable():
       return
 
@@ -341,7 +357,9 @@ class YouCompleteMe( object ):
     request_data[ 'signature_help_state' ] = self._signature_help_state.state
 
     self._AddExtraConfDataIfNeeded( request_data )
-    self._latest_signature_help_request = SignatureHelpRequest( request_data )
+
+    self._latest_signature_help_request = SignatureHelpRequest(
+      request_data )
     self._latest_signature_help_request.Start()
 
 
@@ -352,6 +370,12 @@ class YouCompleteMe( object ):
 
   def GetSignatureHelpResponse( self ):
     return self._latest_signature_help_request.Response()
+
+
+  def ClearSignatureHelp( self ):
+    self.UpdateSignatureHelp( {} )
+    if self._latest_signature_help_request:
+      self._latest_signature_help_request.Reset()
 
 
   def UpdateSignatureHelp( self, signature_info ):
@@ -513,6 +537,11 @@ class YouCompleteMe( object ):
 
 
   def OnBufferVisit( self ):
+    filetype = vimsupport.CurrentFiletypes()[ 0 ]
+    # The constructor of dictionary values starts the request,
+    # so the line below fires a new request only if the dictionary
+    # value is accessed for the first time.
+    self._signature_help_available_requests[ filetype ].Done()
     extra_data = {}
     self._AddUltiSnipsDataIfNeeded( extra_data )
     SendEventNotificationAsync( 'BufferVisit', extra_data = extra_data )


### PR DESCRIPTION
This PR is supposed to accompany puremourning/ycmd-1#19.

The problem with this is that the response of `/signature_help_available` is a literal `True`, `False` or `None` and from there we get the following problems:

- In `client/base_request.py`, `_JsonResponse()` needs the `try`/`except` because "bool has no attribute result".
- In `client/signature_help.py`, class `SignatureHelpAvailableRequest`
  - `Done()` always returns `True`, so all of this is betting on the request getting its response before the timeout.
  - `Response()` just returns whatever `Start()` put into `self._response_future`.
  - `self._response_future` isn't really a "future".

Yeah, it's a terrible hack, so we need to change the request somewhat. I'm open for ideas. There's also the possibility that I missed something big.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/puremourning/youcompleteme/5)
<!-- Reviewable:end -->
